### PR TITLE
fix: make extension run locally

### DIFF
--- a/package.json
+++ b/package.json
@@ -400,6 +400,9 @@
             }
         }
     },
+    "extensionKind": [
+        "ui"
+    ],
     "scripts": {
         "vscode:prepublish": "npm run compile",
         "compile": "tsc -p ./",


### PR DESCRIPTION
Without this extension required to be installed on remote machine while using
remote workspaces

More info: https://code.visualstudio.com/api/advanced-topics/remote-extensions