### PR TITLE
Update namespaces declared using the `module` keyword to use the `namespace` keyword instead.

### DIFF
--- a/source/extension.ts
+++ b/source/extension.ts
@@ -55,7 +55,7 @@ const lineObject = Object.freeze
     "end-line-number": (entry: BracketEntry) => `#${entry.end.position.line +1} `,
     "both-line-numbers": (entry: BracketEntry) => `#${entry.start.position.line +1}-${entry.end.position.line +1} `,
 });
-module Config
+namespace Config
 {
     export const root = vscel.config.makeRoot(packageJson);
     export const mode = root.makeMapEntry("bracketLens.mode", "active-text-editor", modeObject);
@@ -491,7 +491,7 @@ const parseBrackets = (document: vscode.TextDocument) => profile
         return result;
     }
 );
-module position
+namespace position
 {
     export const nextLine = (position: vscode.Position, increment: number = 1) => new vscode.Position
         (


### PR DESCRIPTION
Use of module to declare namespaces is deprecated in TypeScript 6.0 (https://devblogs.microsoft.com/typescript/announcing-typescript-6-0-beta/#deprecated:-legacy-module-syntax-for-namespaces). This is a hard deprecation and this syntax will not work in the future.